### PR TITLE
added support for legacy Concordion 1 Example class

### DIFF
--- a/src/main/java/org/concordion/markdown/ConcordionHtmlSerializer.java
+++ b/src/main/java/org/concordion/markdown/ConcordionHtmlSerializer.java
@@ -28,9 +28,13 @@ public class ConcordionHtmlSerializer extends ToHtmlSerializer {
     private String currentExampleHeading;
     private int currentExampleLevel;
     
-    public ConcordionHtmlSerializer(String targetConcordionNamespacePrefix) {
+    private boolean useLegacyExamples;
+    
+    public ConcordionHtmlSerializer(String targetConcordionNamespacePrefix, boolean useLegacyExamples) {
         super(new RunCommandLinkRenderer(SOURCE_CONCORDION_NAMESPACE_PREFIX, targetConcordionNamespacePrefix));
         statementParser = new ConcordionStatementParser(SOURCE_CONCORDION_NAMESPACE_PREFIX, targetConcordionNamespacePrefix);
+        
+        this.useLegacyExamples = useLegacyExamples;
     }
    
 //=======================================================================================================================
@@ -167,11 +171,17 @@ public class ConcordionHtmlSerializer extends ToHtmlSerializer {
                     String expression = ((ExpLinkNode)child).title;
                     currentExampleHeading = printChildrenToString(node);
                     currentExampleLevel = node.getLevel();
-                    ConcordionStatement command = statementParser.parseCommandValueAndAttributes("example", expression);
-                    printer.println();
-                    printer.print("<div");
-                    printConcordionCommand(command);
-                    printer.print(">");
+                    
+                    if(useLegacyExamples){
+                        printer.println();
+                        printer.print("<div class=\"example\">");
+                    }else{
+                        ConcordionStatement command = statementParser.parseCommandValueAndAttributes("example", expression);
+                        printer.println();
+                        printer.print("<div");
+                        printConcordionCommand(command);
+                        printer.print(">");
+                    }
                     inExample = true;
                 }
             } if (inExample) {

--- a/src/main/java/org/concordion/markdown/MarkdownParser.java
+++ b/src/main/java/org/concordion/markdown/MarkdownParser.java
@@ -10,19 +10,37 @@ import org.pegdown.ast.RootNode;
 public class MarkdownParser {
     private int pegdownExtensions;
 
+    private boolean useLegacyExamples;
+    
     public MarkdownParser() {
         this(0);
     }
     
     public MarkdownParser(int pegdownExtensions) {
+        this(pegdownExtensions, missingExampleCommand());
+    }
+    
+    private static boolean missingExampleCommand(){
+        //look for the name of the ExampleCommand class in concordion
+        //which was added in Concordion 2.0
+        try{
+            Class.forName("org.concordion.internal.command.ExampleCommand");
+            return false;
+        }catch(ClassNotFoundException e){
+            return true;
+        }
+    }
+    
+    public MarkdownParser(int pegdownExtensions, boolean useLegacyExamples) {
         this.pegdownExtensions = pegdownExtensions;
+        this.useLegacyExamples = useLegacyExamples;
     }
 
     public String markdownToHtml(String markdown, String concordionNamespacePrefix) {
         Parser parser = Parboiled.createParser(Parser.class, Extensions.TABLES | Extensions.STRIKETHROUGH | pegdownExtensions, 5000L, Parser.DefaultParseRunnerProvider);
         PegDownProcessor processor = new PegDownProcessor();
         RootNode root = parser.parse(processor.prepareSource(markdown.toCharArray()));
-        ToHtmlSerializer serializer = new ConcordionHtmlSerializer(concordionNamespacePrefix);
+        ToHtmlSerializer serializer = new ConcordionHtmlSerializer(concordionNamespacePrefix, useLegacyExamples);
         return serializer.toHtml(root);
     }
 }

--- a/src/test/java/spec/concordion/markdown/AbstractGrammar.java
+++ b/src/test/java/spec/concordion/markdown/AbstractGrammar.java
@@ -1,0 +1,31 @@
+package spec.concordion.markdown;
+
+import java.io.File;
+
+import org.concordion.api.extension.Extension;
+import org.concordion.ext.MarkdownExtension;
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.concordion.internal.FileTarget;
+import org.concordion.markdown.MarkdownParser;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+public abstract class AbstractGrammar {
+    MarkdownParser markdownParser;
+
+    @Extension
+    public MarkdownExtension extension = new MarkdownExtension().withSourceHtmlSavedTo(new FileTarget(new File("/tmp")));
+    
+   
+    public AbstractGrammar(boolean useLegacyExamples){
+       markdownParser = new MarkdownParser(0, useLegacyExamples);
+    }
+    
+    public String translate(String markdown) {
+        String html = markdownParser.markdownToHtml(markdown, "concordion");
+        if (html.startsWith("<p>") && html.endsWith("</p>")) {
+            html = html.substring(3, html.length()-4);
+        }
+        return html;
+    }
+}

--- a/src/test/java/spec/concordion/markdown/Grammar.java
+++ b/src/test/java/spec/concordion/markdown/Grammar.java
@@ -9,18 +9,11 @@ import org.concordion.internal.FileTarget;
 import org.concordion.markdown.MarkdownParser;
 import org.junit.runner.RunWith;
 
-@RunWith(ConcordionRunner.class)
-public class Grammar {
-    MarkdownParser markdownParser = new MarkdownParser();
 
-    @Extension
-    public MarkdownExtension extension = new MarkdownExtension().withSourceHtmlSavedTo(new FileTarget(new File("/tmp")));
-    
-    public String translate(String markdown) {
-        String html = markdownParser.markdownToHtml(markdown, "concordion");
-        if (html.startsWith("<p>") && html.endsWith("</p>")) {
-            html = html.substring(3, html.length()-4);
-        }
-        return html;
+public class Grammar extends AbstractGrammar{
+  
+    public Grammar(){
+        super(false);
     }
+   
 }

--- a/src/test/java/spec/concordion/markdown/LegacyExample.java
+++ b/src/test/java/spec/concordion/markdown/LegacyExample.java
@@ -1,0 +1,8 @@
+package spec.concordion.markdown;
+
+public class LegacyExample extends AbstractGrammar{
+    
+    public LegacyExample(){
+        super(true);
+    }
+}

--- a/src/test/resources/spec/concordion/markdown/Grammar.md
+++ b/src/test/resources/spec/concordion/markdown/Grammar.md
@@ -822,6 +822,10 @@ HTML entities in the text value are encoded correctly.
   </table>
 </div>
 
+
+##Caveats
+* [What if My Version of Concordion Doesn't Support the Example Command] (LegacyExample.html "c:run")
+
 ##TODO
 
 ### Support for Concordion commands in other namespaces, eg extensions

--- a/src/test/resources/spec/concordion/markdown/LegacyExample.md
+++ b/src/test/resources/spec/concordion/markdown/LegacyExample.md
@@ -1,0 +1,58 @@
+# Support for Legacy Examples
+The Concordion Example Command wasn't added until Concordion 2.0.  Before that, examples were placed in a `div` with the special class name `example` which the Concordion CSS knew how to style correctly.
+
+Whichever version of Example, your version of Concordion supports, the Markdown syntax is exactly the same.However, when using the older version, the example name in the link is ignored.
+
+`### [Header text](- "ignored")`
+
+which creates:
+
+```
+<div class="example">
+    <h3>Header text</h3>
+```    
+
+where `###` can be any level of [header](https://daringfireball.net/projects/markdown/syntax#header), using either atx or setext syntax.
+
+<div class="example">
+  <h3>Examples</h3>
+  <table concordion:execute="#html=translate(#md)">
+    <tr>
+      <th>Description</th>
+      <th concordion:set="#md">Markdown</th>
+      <th concordion:assertEquals="#html">Resulting HTML</th>
+    </tr>
+
+    <tr>
+      <td>h4 example using atx-style syntax</td>
+      <td>
+        <pre>      
+#### [Example 1](- "calculator")
+x
+        </pre>
+      </td>
+      <td>
+      <![CDATA[
+<div class="example"> <h4>Example 1</h4> <p>x</p></div>  
+]]> 
+      </td>
+    </tr>
+    
+    <tr>
+      <td>h1 example using setext-style syntax</td>
+      <td>
+        <pre>      
+[Example 2](- "setext")
+=====================================================
+x
+        </pre>
+      </td>
+      <td>
+ <![CDATA[
+<div class="example"> <h1>Example 2</h1> <p>x</p></div>  
+]]> 
+      </td>
+    </tr>
+    
+  </table>
+</div> 


### PR DESCRIPTION
As discussed on the dev mailing list.

These changes allow the Example Markdown syntax to revert to the the legacy Concordion 1 `div class="example"` version if the Concordion 2 class `org.concordion.internal.command.ExampleCommand` does not exist.

Added boolean flag to ConcordionHtmlSerializer constructor to signal which versions of Examples to use and added similar flag to MarkDownParser.  If constructor without flag is used, then code will perform a `Class.forName("org.concordion.internal.command.ExampleCommand")` to determine what the flag should be set to.

Include Specification as well to explain it.
